### PR TITLE
Refactors isEmpty() methods to empty()

### DIFF
--- a/sdk/src/main/java/com/tmsdurham/actions/DialogflowApp.kt
+++ b/sdk/src/main/java/com/tmsdurham/actions/DialogflowApp.kt
@@ -434,7 +434,7 @@ class DialogflowApp : AssistantApp<DialogflowRequest, DialogflowResponse> {
      */
     fun ask(inputPrompt: RichResponse, noInputs: MutableList<String>? = null): ResponseWrapper<DialogflowResponse>? {
         debug("ask: inputPrompt=$inputPrompt, noInputs=$noInputs")
-        if (inputPrompt.isEmpty()) {
+        if (inputPrompt.empty()) {
             handleError("Invalid input prompt")
             return null
         }
@@ -655,7 +655,7 @@ class DialogflowApp : AssistantApp<DialogflowRequest, DialogflowResponse> {
      */
     fun askWithCarousel(inputPrompt: RichResponse, carousel: Carousel): ResponseWrapper<DialogflowResponse>? {
         debug("askWithCarousel: inputPrompt=$inputPrompt, carousel=$carousel")
-        if (inputPrompt.isEmpty()) {
+        if (inputPrompt.empty()) {
             handleError("Invalid input prompt")
             return null
         }
@@ -774,7 +774,7 @@ class DialogflowApp : AssistantApp<DialogflowRequest, DialogflowResponse> {
      */
     override fun tell(richResponse: RichResponse?): ResponseWrapper<DialogflowResponse>? {
         debug("tell: richResponse=$richResponse")
-        if (richResponse == null || richResponse.isEmpty()) {
+        if (richResponse == null || richResponse.empty()) {
             handleError("Invalid rich response")
             return null
         }
@@ -784,7 +784,7 @@ class DialogflowApp : AssistantApp<DialogflowRequest, DialogflowResponse> {
 
     override fun tell(simpleResponse: SimpleResponse): ResponseWrapper<DialogflowResponse>? {
         debug("tell: speechResponse=$simpleResponse")
-        if (simpleResponse.isEmpty()) {
+        if (simpleResponse.empty()) {
             handleError("Invalid speech response")
             return null
         }
@@ -1217,7 +1217,7 @@ class DialogflowApp : AssistantApp<DialogflowRequest, DialogflowResponse> {
      */
     fun buildResponse(simpleResponse: SimpleResponse, expectUserResponse: Boolean, noInputs: MutableList<String>? = null): ResponseWrapper<DialogflowResponse>? {
         debug("buildResponse_: simpleResponse=$simpleResponse, expectUserResponse=$expectUserResponse, noInputs=$noInputs")
-        if (simpleResponse.isEmpty()) {
+        if (simpleResponse.empty()) {
             handleError("Invalid text to speech")
             return null
         }
@@ -1237,7 +1237,7 @@ class DialogflowApp : AssistantApp<DialogflowRequest, DialogflowResponse> {
      */
     fun buildResponse(richResponse: RichResponse, expectUserResponse: Boolean, noInputs: MutableList<String>? = null): ResponseWrapper<DialogflowResponse>? {
         debug("buildResponse_: textToSpeech=$richResponse, expectUserResponse=$expectUserResponse, noInputs=$noInputs")
-        if (richResponse.isEmpty()) {
+        if (richResponse.empty()) {
             handleError("Invalid text to speech")
             return null
         }

--- a/sdk/src/main/java/com/tmsdurham/actions/ResponseBuilder.kt
+++ b/sdk/src/main/java/com/tmsdurham/actions/ResponseBuilder.kt
@@ -39,7 +39,7 @@ data class SimpleResponse(
         var textToSpeech: String? = null,
         var ssml: String? = null,
         var displayText: String? = null) {
-    fun isEmpty() = textToSpeech.isNullOrBlank() && ssml.isNullOrBlank() && displayText.isNullOrBlank()
+    fun empty() = textToSpeech.isNullOrBlank() && ssml.isNullOrBlank() && displayText.isNullOrBlank()
 }
 
 /**
@@ -109,7 +109,7 @@ data class RichResponse(
         var altLinkSuggestion: AltLinkSuggestion? = null,
         var linkOutSuggestion: LinkOutSuggestion? = null) {
 
-    fun isEmpty() = (items.isEmpty() &&
+    fun empty() = (items.isEmpty() &&
             (suggestions == null || suggestions!!.isEmpty()) &&
             (altLinkSuggestion == null) &&
             (linkOutSuggestion == null))
@@ -123,7 +123,7 @@ data class RichResponse(
      */
     fun addSimpleResponse(speech: String, displayText: String? = null): RichResponse {
         val simpleResponse = SimpleResponse(textToSpeech = speech, displayText = displayText)
-        if (simpleResponse.isEmpty()) {
+        if (simpleResponse.empty()) {
             error("Invalid simpleResponse")
             return this
         }


### PR DESCRIPTION
The presence of isEmpty() causes some kotlin JSON parsers (e.g. fasterxml as used by AWS Lambda) to generate a field labelled 'empty' because isEmpty() follows the pattern of a boolean accessor.